### PR TITLE
[FEAT] Improve code to remove the need of API proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This sketch was designed to run reliably on ESP8266 devices with limited RAM:
 - **Stream-based JSON parsing** — responses parsed directly from the HTTP stream, never copied to a String
 - **ArduinoJson filters** — only needed fields are allocated in the JSON document
 - **Static pricing arrays** — prices stored in plain `double[]`, no JSON document overhead
-- **Optimised TLS buffers** — BearSSL configured with 1024-byte buffers (~42 KB vs default ~60 KB)
+- **Optimised TLS buffers** — BearSSL configured with 1024-byte buffers (~28 KB vs default ~60 KB)
 - **Static storage** — configuration and symbol strings stored with `static` to avoid linker conflicts
 
 ## Troubleshooting

--- a/bitcoin-tracker-lcd/README.md
+++ b/bitcoin-tracker-lcd/README.md
@@ -1,0 +1,51 @@
+# ESP8266 Bitcoin Tracker — LCD Variant
+
+> **Deprecated.** This variant is no longer maintained. Use [`bitcoin-tracker-oled`](../bitcoin-tracker-oled) instead — it connects directly to Binance with no proxy required.
+
+---
+
+This sketch displays live cryptocurrency prices on a **16×2 LCD** display (I2C). Unlike the current OLED version, it does **not** talk to Binance directly. Instead, it relies on a separate HTTP proxy server running on your local network.
+
+## Prerequisites
+
+### 1. Run the proxy server
+
+This sketch requires the [bitcoin-tracker-proxy](https://github.com/alejandrosnz/bitcoin-tracker-proxy) to be running and reachable from your ESP8266 on the same network.
+
+Follow the setup instructions in that repository (Node.js or Docker). Once running, the proxy exposes:
+
+| Endpoint | Returns |
+|----------|---------|
+| `GET /api/ticker/current_price/{symbol}` | `{ "currentPrice": "..." }` |
+| `GET /api/ticker/closing_price/{symbol}` | `{ "closingPrice": ... }` |
+
+### 2. Hardware
+
+- **ESP8266** (NodeMCU, Wemos D1 Mini, or compatible)
+- **16×2 LCD** with I2C backpack (I2C address `0x3F`)
+  - SDA → D1
+  - SCL → D2
+
+### 3. Required Libraries
+
+Install via **Sketch** → **Include Library** → **Manage Libraries**:
+
+- `ArduinoJson` by Benoit Blanchon
+- `LiquidCrystal I2C` by Frank de Brabander
+
+## Configuration
+
+Edit `bitcoin-tracker-lcd.ino` before flashing:
+
+```cpp
+const char* ssid     = "your_ssid_here";
+const char* password = "wifi_pass_here";
+
+String api_host = "http://<proxy-ip>:3001";  // IP of the machine running the proxy
+```
+
+## Why is this deprecated?
+
+The proxy architecture was introduced to work around memory limitations of the ESP8266 when parsing large API responses. The OLED variant has since solved this problem directly on the device using stream-based JSON parsing, eliminating the need for an external server entirely.
+
+See [`bitcoin-tracker-oled`](../bitcoin-tracker-oled) for the current, actively maintained version.

--- a/bitcoin-tracker-oled/api.cpp
+++ b/bitcoin-tracker-oled/api.cpp
@@ -1,0 +1,126 @@
+/**
+ * @file api.cpp
+ * @brief Binance REST API implementation.
+ *
+ * Uses WiFiClientSecure (BearSSL) with deliberately reduced TLS buffers to
+ * keep heap usage around 28 KB instead of the default ~60 KB.  Certificate
+ * verification is disabled (setInsecure) — acceptable for a personal project
+ * where authenticity of the price data is not safety-critical.
+ *
+ * Both functions parse the HTTP response directly from the stream using
+ * ArduinoJson, so the full payload is never materialised as a String.
+ */
+
+#include "api.h"
+
+#include <Arduino.h>
+#include <ESP8266HTTPClient.h>
+#include <WiFiClientSecure.h>
+
+// Must be defined before including ArduinoJson to ensure 64-bit float arithmetic.
+#define ARDUINOJSON_USE_DOUBLE 1
+#include <ArduinoJson.h>
+
+#include "config.h"
+#include "debug.h"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @brief Apply standard TLS settings to a WiFiClientSecure instance.
+ *
+ * Called once per request before HTTPClient::begin().  Keeping this in one
+ * place makes it easy to tighten security (e.g. add a certificate fingerprint)
+ * without touching every call-site.
+ */
+static void configure_tls(WiFiClientSecure& client) {
+  client.setInsecure();                              // skip certificate verification
+  client.setBufferSizes(TLS_READ_BUFFER, TLS_WRITE_BUFFER);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+double get_current_price(const char* symbol) {
+  WiFiClientSecure client;
+  configure_tls(client);
+
+  HTTPClient http;
+  String url = String(F("https://")) + BINANCE_HOST
+             + F("/api/v3/ticker/price?symbol=") + symbol + F("USDT");
+  DEBUG_PRINT(url);
+
+  http.begin(client, url);
+  digitalWrite(BUILTIN_LED, LOW);   // blink LED while request is in flight
+  int code = http.GET();
+  digitalWrite(BUILTIN_LED, HIGH);
+
+  double price = -1;
+
+  if (code == HTTP_CODE_OK) {
+    // Discard everything except the single "price" field to minimise the
+    // amount of memory ArduinoJson allocates for the parsed document.
+    StaticJsonDocument<32> filter;
+    filter[F("price")] = true;
+
+    StaticJsonDocument<64> doc;
+    DeserializationError err = deserializeJson(
+        doc, http.getStream(), DeserializationOption::Filter(filter));
+
+    if (err) {
+      Serial.print(F("[api] JSON error (current): "));
+      Serial.println(err.f_str());
+    } else {
+      price = doc[F("price")].as<double>();
+      DEBUG_PRINT(price);
+    }
+  } else {
+    Serial.print(F("[api] HTTP error (current): "));
+    Serial.println(code);
+  }
+
+  http.end();
+  return price;
+}
+
+double get_closing_price(const char* symbol) {
+  WiFiClientSecure client;
+  configure_tls(client);
+
+  HTTPClient http;
+  String url = String(F("https://")) + BINANCE_HOST
+             + F("/api/v3/klines?symbol=") + symbol + F("USDT&interval=1d&limit=1");
+  DEBUG_PRINT(url);
+
+  http.begin(client, url);
+  digitalWrite(BUILTIN_LED, LOW);
+  int code = http.GET();
+  digitalWrite(BUILTIN_LED, HIGH);
+
+  double price = -1;
+
+  if (code == HTTP_CODE_OK) {
+    // The klines response is ~160 bytes for limit=1; a 512-byte document is
+    // sufficient and a filter would add more complexity than it saves here.
+    StaticJsonDocument<512> doc;
+    DeserializationError err = deserializeJson(doc, http.getStream());
+
+    if (err) {
+      Serial.print(F("[api] JSON error (closing): "));
+      Serial.println(err.f_str());
+    } else {
+      // Klines layout: [[openTime, open, high, low, close, volume, closeTime, ...]]
+      price = doc[0][1].as<double>();
+      DEBUG_PRINT(price);
+    }
+  } else {
+    Serial.print(F("[api] HTTP error (closing): "));
+    Serial.println(code);
+  }
+
+  http.end();
+  return price;
+}

--- a/bitcoin-tracker-oled/api.h
+++ b/bitcoin-tracker-oled/api.h
@@ -1,0 +1,51 @@
+/**
+ * @file api.h
+ * @brief Binance REST API helpers for real-time price data.
+ *
+ * Both functions open a fresh HTTPS connection, parse the response as a
+ * stream (no intermediate String allocation), and close the connection.
+ * TLS buffer sizes are read from config.h (TLS_READ_BUFFER / TLS_WRITE_BUFFER).
+ */
+#pragma once
+
+/**
+ * @brief Fetch the latest traded price for a symbol from Binance.
+ *
+ * Endpoint: GET https://api.binance.com/api/v3/ticker/price?symbol=<SYMBOL>USDT
+ *
+ * Example response (≈60 bytes):
+ * @code
+ * {"symbol":"BTCUSDT","price":"60950.01000000"}
+ * @endcode
+ *
+ * Memory strategy:
+ *  - WiFiClientSecure with reduced TLS buffers (see config.h)
+ *  - ArduinoJson filter  → only the "price" key is allocated in the document
+ *  - Stream-based deserialization → response is never copied into a String
+ *
+ * @param symbol  Binance base asset (e.g. "BTC", "ETH").
+ * @return Price as double, or -1 on HTTP/parse error.
+ */
+double get_current_price(const char* symbol);
+
+/**
+ * @brief Fetch the midnight-UTC opening price for a symbol from Binance.
+ *
+ * Endpoint: GET https://api.binance.com/api/v3/klines?symbol=<SYMBOL>USDT&interval=1d&limit=1
+ *
+ * Example response (≈160 bytes):
+ * @code
+ * [[1499040000000,"60000.00","62000.00","59000.00","61000.00","12345.00",...]]
+ * @endcode
+ *
+ * @c klines[0][1] is the open price of the current daily candle, which is the
+ * price at exactly midnight UTC — semantically equivalent to CryptoCompare's
+ * @c OPENDAY field. This value is used as the daily reference for % change.
+ *
+ * The response is small enough (≈160 bytes) that no filter is required;
+ * a StaticJsonDocument<512> holds the full document comfortably.
+ *
+ * @param symbol  Binance base asset (e.g. "BTC", "ETH").
+ * @return Opening price as double, or -1 on HTTP/parse error.
+ */
+double get_closing_price(const char* symbol);

--- a/bitcoin-tracker-oled/bitcoin-tracker-oled.ino
+++ b/bitcoin-tracker-oled/bitcoin-tracker-oled.ino
@@ -1,17 +1,18 @@
 #include <ESP8266WiFi.h>
 #include <ESP8266HTTPClient.h>
-#include <WiFiClient.h>
+#include <WiFiClientSecure.h>
 #define ARDUINOJSON_USE_DOUBLE 1
 #include <ArduinoJson.h>
-#include <Wire.h> 
+#include <Wire.h>
 #include <avr/pgmspace.h>
 
 #include "config.h"
 #include "icons.h"
 
+// Uncomment to enable verbose serial output
 // #define DEBUG
 #ifdef DEBUG
-  #define DEBUG_PRINT(x)  Serial.println (x)
+  #define DEBUG_PRINT(x) Serial.println(x)
 #else
   #define DEBUG_PRINT(x)
 #endif
@@ -21,271 +22,253 @@
 #include <Fonts/FreeMonoBold9pt7b.h>
 Adafruit_SH1106G display = Adafruit_SH1106G(OLED_WIDTH, OLED_HEIGHT, &Wire, OLED_RESET);
 
-// Create custom symbols for LCD
-byte arrow_up[8] = {
-B00000,B00100,B01010,B10101,
-B00100,B00100,B00100,B00000,};
-byte arrow_down[8] = {
-B00000,B00100,B00100,B00100,
-B10001,B01010,B00100,B00000,};
+// ── Price storage ─────────────────────────────────────────────────────────────
+// Simple parallel arrays indexed by position in list_of_symbols[].
+// Replaces the old nested DynamicJsonDocument, eliminating heap fragmentation.
+double current_prices[size_of_list_of_symbols];
+double closing_prices[size_of_list_of_symbols];
 
-#define JSON_SIZE_PER_SYMBOL 75
-#define CLOSING_PRICE "clse"
-#define CURRENT_PRICE "curr"
-
-DynamicJsonDocument list_of_prices(size_of_list_of_symbols * JSON_SIZE_PER_SYMBOL);
-DynamicJsonDocument json_doc(1000);
-
-int symbol_index;
+int  symbol_index;
 long start_time;
 
-void setup() 
+// ── setup ─────────────────────────────────────────────────────────────────────
+void setup()
 {
-  // Start Serial Port with baud rate 9600
   Serial.begin(9600);
-  
-  // OLED setup
+
+  // OLED
   Wire.begin(OLED_SDA, OLED_SCL);
   delay(250);
   display.begin(OLED_I2C_ADDR, true);
   display.setTextColor(SH110X_WHITE);
   display.clearDisplay();
-  display.println("Connecting...");
+  display.println(F("Connecting..."));
   display.display();
-  
-  // // Create custom chars
-  // lcd.createChar(0, arrow_up);
-  // lcd.createChar(1, arrow_down);
 
-  // Set built-in led to output
+  // Built-in LED: HIGH = off (active low on ESP8266)
   pinMode(BUILTIN_LED, OUTPUT);
   digitalWrite(BUILTIN_LED, HIGH);
 
-  // Start Wi-Fi connection
+  // Wi-Fi
   WiFi.begin(ssid, password);
-
-  while (WiFi.status() != WL_CONNECTED){
+  while (WiFi.status() != WL_CONNECTED) {
     delay(1000);
-    Serial.print(".");
+    Serial.print('.');
   }
-  Serial.print("Connected to WiFi! IP: ");
+  Serial.print(F("Connected! IP: "));
   Serial.println(WiFi.localIP());
   display.clearDisplay();
-  display.println("Connected to WiFi!");
+  display.println(F("Connected to WiFi!"));
   display.display();
 
-  // Get initial price values
-  for (byte i = 0; i < size_of_list_of_symbols; i++) {
-    String symbol = list_of_symbols[i];
-    list_of_prices[symbol][CLOSING_PRICE] = get_closing_price(symbol);
-    list_of_prices[symbol][CURRENT_PRICE] = get_current_price(symbol);
+  // Fetch initial prices for every symbol
+  for (int i = 0; i < size_of_list_of_symbols; i++) {
+    closing_prices[i] = get_closing_price(list_of_symbols[i]);
+    current_prices[i] = get_current_price(list_of_symbols[i]);
   }
-  // Print first price values
-  print_to_screen(list_of_prices[list_of_symbols[0]][CURRENT_PRICE], \
-                  list_of_prices[list_of_symbols[0]][CURRENT_PRICE], \
-                  list_of_prices[list_of_symbols[0]][CLOSING_PRICE], \
-                  list_of_symbols[0]);
-  
+
+  print_to_screen(current_prices[0], current_prices[0], closing_prices[0], list_of_symbols[0]);
+
   symbol_index = 0;
-  start_time = millis();
+  start_time   = millis();
 }
 
-void loop() 
+// ── loop ──────────────────────────────────────────────────────────────────────
+void loop()
 {
-  String symbol;
+  if (WiFi.status() != WL_CONNECTED) return;
 
-  if (WiFi.status() == WL_CONNECTED) {  
-    long current_millis = millis();
+  long current_millis = millis();
 
-    if(current_millis > start_time + (SECONDS_TO_DISPLAY_EACH_SYMBOL * 1000)){
-      start_time = current_millis;
-      symbol_index += 1;
-      if (symbol_index >= size_of_list_of_symbols) {
-        symbol_index = 0;
-      }
-    }
-    symbol = list_of_symbols[symbol_index];
-    
-    double new_price = get_current_price(symbol);
-    if (new_price != list_of_prices[symbol][CURRENT_PRICE]) {
-      print_to_screen(new_price, \
-                      list_of_prices[symbol][CURRENT_PRICE], \
-                      list_of_prices[symbol][CLOSING_PRICE], \
-                      symbol);
-
-      list_of_prices[symbol][CURRENT_PRICE] = new_price;
-    }
-    delay(poll_delay);
-  }
-}
-
-double get_current_price(String symbol) {
-  String _current_price_path = current_price_path;
-  _current_price_path.replace(F("{symbol}"), symbol);
-  String jsonBuffer = sendGET(api_host, _current_price_path);
-  DEBUG_PRINT(jsonBuffer);
-
-  DeserializationError error = deserializeJson(json_doc, jsonBuffer);
-  if (error) {
-    Serial.print(F("Failed to parse JSON"));
-    Serial.println(error.f_str());
-    display.clearDisplay();
-    display.print(F("Failed to parse JSON"));
-    display.display();
-    return -1;
+  // Rotate symbol
+  if (current_millis > start_time + (SECONDS_TO_DISPLAY_EACH_SYMBOL * 1000L)) {
+    start_time = current_millis;
+    symbol_index = (symbol_index + 1) % size_of_list_of_symbols;
   }
 
-  String current_price = json_doc[F("currentPrice")];
+  double new_price = get_current_price(list_of_symbols[symbol_index]);
 
-  return current_price.toDouble();
-}
-
-double get_closing_price(String symbol) {
-  String _closing_price_path = closing_price_path;
-  _closing_price_path.replace(F("{symbol}"), symbol);
-  String jsonBuffer = sendGET(api_host, _closing_price_path);
-  DEBUG_PRINT(jsonBuffer);
-
-  DeserializationError error = deserializeJson(json_doc, jsonBuffer);
-  if (error) {
-    Serial.print(F("Failed to parse JSON"));
-    Serial.println(error.f_str());
-    display.clearDisplay();
-    display.print(F("Failed to parse JSON"));
-    display.display();
-    return -1;
+  if (new_price > 0 && new_price != current_prices[symbol_index]) {
+    print_to_screen(new_price,
+                    current_prices[symbol_index],
+                    closing_prices[symbol_index],
+                    list_of_symbols[symbol_index]);
+    current_prices[symbol_index] = new_price;
   }
 
-  double closing_price = json_doc[F("closingPrice")];
-
-  return closing_price;
+  delay(poll_delay);
 }
 
+// ── get_current_price ─────────────────────────────────────────────────────────
+// Calls GET /api/v3/ticker/price?symbol={SYMBOL}USDT
+// Response: {"symbol":"BTCUSDT","price":"60950.01000000"}  (~60 bytes)
+//
+// Uses:
+//  • WiFiClientSecure with certificate check disabled (personal project)
+//  • Reduced TLS buffers to save ~30 KB of heap vs default
+//  • ArduinoJson filter  → only the "price" key is allocated in the document
+//  • Stream-based parsing → response is never copied into a String
+double get_current_price(const char* symbol) {
+  WiFiClientSecure client;
+  client.setInsecure();
+  client.setBufferSizes(TLS_READ_BUFFER, TLS_WRITE_BUFFER);
 
-String sendGET(String _api_host, String _path) {
-  String url = _api_host + _path;
-  
-  WiFiClient client;
   HTTPClient http;
-
+  String url = String(F("https://")) + BINANCE_HOST +
+               F("/api/v3/ticker/price?symbol=") + symbol + F("USDT");
   DEBUG_PRINT(url);
-  http.begin(client, url);
-    
-  // Send HTTP POST request
-  digitalWrite(BUILTIN_LED, LOW);
-  int httpResponseCode = http.GET();
-  digitalWrite(BUILTIN_LED, HIGH);
-  
-  String payload = "{}"; 
-  
-  if (httpResponseCode > 0) {
-    Serial.print(F("HTTP Response code: "));
-    Serial.println(httpResponseCode);
-    payload = http.getString();
-  }
-  else {
-    Serial.print(F("HTTP error! "));
-    Serial.println(httpResponseCode);
-  }
-  // Free resources
-  http.end();
 
-  return payload;
+  http.begin(client, url);
+  digitalWrite(BUILTIN_LED, LOW);
+  int code = http.GET();
+  digitalWrite(BUILTIN_LED, HIGH);
+
+  double price = -1;
+
+  if (code == HTTP_CODE_OK) {
+    // Filter: discard every field except "price"
+    StaticJsonDocument<32> filter;
+    filter[F("price")] = true;
+
+    StaticJsonDocument<64> doc;
+    DeserializationError err = deserializeJson(doc, http.getStream(),
+                                               DeserializationOption::Filter(filter));
+    if (err) {
+      Serial.print(F("JSON error (current): "));
+      Serial.println(err.f_str());
+    } else {
+      price = doc[F("price")].as<double>();
+      DEBUG_PRINT(price);
+    }
+  } else {
+    Serial.print(F("HTTP error (current): "));
+    Serial.println(code);
+  }
+
+  http.end();
+  return price;
 }
 
-void print_to_screen(double current_price, double previous_price, double closing_price, String symbol) {
+// ── get_closing_price ─────────────────────────────────────────────────────────
+// Calls GET /api/v3/klines?symbol={SYMBOL}USDT&interval=1d&limit=1
+// Response: [[openTime,"openPrice","highPrice","lowPrice","closePrice",...]]
+//
+// klines[0][1] = open price of today's daily candle = midnight UTC open price
+// This is semantically identical to CryptoCompare's OPENDAY field.
+//
+// The response is ~160 bytes; StaticJsonDocument<512> is plenty.
+// No filter needed at this size – the full document fits comfortably.
+double get_closing_price(const char* symbol) {
+  WiFiClientSecure client;
+  client.setInsecure();
+  client.setBufferSizes(TLS_READ_BUFFER, TLS_WRITE_BUFFER);
+
+  HTTPClient http;
+  String url = String(F("https://")) + BINANCE_HOST +
+               F("/api/v3/klines?symbol=") + symbol + F("USDT&interval=1d&limit=1");
+  DEBUG_PRINT(url);
+
+  http.begin(client, url);
+  digitalWrite(BUILTIN_LED, LOW);
+  int code = http.GET();
+  digitalWrite(BUILTIN_LED, HIGH);
+
+  double price = -1;
+
+  if (code == HTTP_CODE_OK) {
+    StaticJsonDocument<512> doc;
+    DeserializationError err = deserializeJson(doc, http.getStream());
+    if (err) {
+      Serial.print(F("JSON error (closing): "));
+      Serial.println(err.f_str());
+    } else {
+      // Array layout: [[openTime, open, high, low, close, volume, ...]]
+      price = doc[0][1].as<double>();
+      DEBUG_PRINT(price);
+    }
+  } else {
+    Serial.print(F("HTTP error (closing): "));
+    Serial.println(code);
+  }
+
+  http.end();
+  return price;
+}
+
+// ── print_to_screen ───────────────────────────────────────────────────────────
+void print_to_screen(double current_price, double previous_price, double closing_price, const char* symbol) {
   display.clearDisplay();
 
-  // Print PRICE
+  // Price value
   display.setTextSize(3);
   String current_price_str = String(current_price, 4);
   int dec_index = current_price_str.indexOf('.');
-  if (current_price >= 1000000) {  // + 1M
+  if (current_price >= 1000000) {         // 1M+
     display.setCursor(0, 4);
     display.print(current_price_str.substring(0, dec_index));
-  } else if (current_price >= 100000) { // 100K to 1M
+  } else if (current_price >= 100000) {   // 100K–1M
     display.setCursor(5, 4);
     display.print(current_price_str.substring(0, dec_index));
-  } else if (current_price >= 1000) {   // 1K to 100K
+  } else if (current_price >= 1000) {     // 1K–100K
     display.setCursor(5, 4);
     display.print(current_price_str.substring(0, dec_index));
     display.setTextSize(2);
     display.setCursor(dec_index * 17 + 5, 11);
     display.print(current_price_str.substring(dec_index, dec_index + (7 - dec_index)));
-  } else if (current_price >= 10) {     // 10 to 1K
+  } else if (current_price >= 10) {       // 10–1K
     display.setCursor(20, 4);
     display.print(current_price_str.substring(0, dec_index));
     display.setTextSize(2);
     display.setCursor(dec_index * 17 + 20, 11);
     display.print(current_price_str.substring(dec_index, dec_index + (6 - dec_index)));
-  } else {  // less than 10$
+  } else {                                // < $10
     display.setCursor(5, 4);
     display.print(current_price_str);
   }
 
-  // Print $ sign
+  // $ sign
   if (current_price < 1000000) {
     display.setCursor(115, 11);
     display.setTextSize(2);
-    display.print("$");
+    display.print('$');
   }
 
-  // Print Crypto symbol
+  // Symbol label inside rounded rectangle
   display.setCursor(15, 37);
   display.setTextSize(2);
-  display.print(symbol.substring(0, 3));
+  display.print(symbol);  // already 3-char max per convention
+  display.drawRoundRect(10, 32, 44, 24, 8, SH110X_WHITE);
 
-  int x = 15;
-  int y = 37;
-  display.drawRoundRect(x - 5 , y - 5, 44, 24, 8, SH110X_WHITE);
-
-  // Print UP or DOWN
+  // Direction icon (vs midnight UTC open)
   double diff = (current_price - closing_price) / closing_price * 100;
-  if (diff >= 3.5) {
-    display.drawBitmap(59, 37, bitmap_up_double, ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
-  } else if (diff >= 1.5 && diff < 3.5) {
-    display.drawBitmap(59, 37, bitmap_up_single, ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
-  } else if (diff >= 0 && diff < 1.5) {
-    display.drawBitmap(59, 37, bitmap_up_thin, ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
-  } else if (diff < 0 && diff > -1.5) {
-    display.drawBitmap(59, 37, bitmap_down_thin, ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
-  } else if (diff <= -1.5 && diff > -3.5) {
-    display.drawBitmap(59, 37, bitmap_down_single, ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
-  } else if (diff <= -3.5) {
-    display.drawBitmap(59, 37, bitmap_down_double, ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
-  }
+  if      (diff >= 3.5)              display.drawBitmap(59, 37, bitmap_up_double,   ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
+  else if (diff >= 1.5)              display.drawBitmap(59, 37, bitmap_up_single,   ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
+  else if (diff >= 0)                display.drawBitmap(59, 37, bitmap_up_thin,     ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
+  else if (diff > -1.5)              display.drawBitmap(59, 37, bitmap_down_thin,   ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
+  else if (diff > -3.5)              display.drawBitmap(59, 37, bitmap_down_single, ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
+  else                               display.drawBitmap(59, 37, bitmap_down_double, ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
 
-  float percentage_diff = abs(((current_price - closing_price) / closing_price) * 100);
-  if (DIFF_PRINT_PERCENTAGE_AND_VALUE == true) {
-    // Print diff %
+  // Percentage (and optionally absolute) change
+  float pct = abs(((current_price - closing_price) / closing_price) * 100);
+  if (DIFF_PRINT_PERCENTAGE_AND_VALUE) {
     display.setCursor(80, 35);
     display.setTextSize(1);
-    display.print(percentage_diff, 2);
-    display.print("%");
-
-    // // Print diff num
+    display.print(pct, 2);
+    display.print('%');
     display.setCursor(80, 45);
     display.setTextSize(1);
     display.print(abs(current_price - closing_price), 2);
-
   } else {
-    // Print larger diff %
     display.setCursor(80, 37);
     display.setTextSize(2);
-    display.print(percentage_diff, (percentage_diff < 10) ? 1 : 0);
-    if (percentage_diff >= 10) {
+    display.print(pct, (pct < 10) ? 1 : 0);
+    if (pct >= 10) {
       display.setTextSize(1);
-      display.print(" ");
+      display.print(' ');
       display.setTextSize(2);
     }
-    display.print("%");
+    display.print('%');
   }
 
-  // Print reference date
-  // display.setCursor(110, 40);
-  // display.setTextSize(1);
-  // display.print("1D");
-
-  // Refresh
   display.display();
 }

--- a/bitcoin-tracker-oled/bitcoin-tracker-oled.ino
+++ b/bitcoin-tracker-oled/bitcoin-tracker-oled.ino
@@ -1,42 +1,72 @@
+/**
+ * @file bitcoin-tracker-oled.ino
+ * @brief ESP8266 crypto price tracker with SH1106G OLED display.
+ *
+ * Displays real-time prices and a daily-change indicator for one or more
+ * crypto assets fetched directly from the Binance REST API over HTTPS.
+ * No proxy or external server is required.
+ *
+ * ── Hardware ────────────────────────────────────────────────────────────────
+ *  - ESP8266 board (NodeMCU, Wemos D1 Mini, or compatible)
+ *  - SH1106G 128×64 OLED via I2C (default address 0x3C)
+ *    SDA → D1  |  SCL → D2  (configurable in config.h)
+ *
+ * ── Dependencies (Arduino Library Manager) ──────────────────────────────────
+ *  - ArduinoJson  ≥ 6.x   (Benoit Blanchon)
+ *  - Adafruit GFX Library
+ *  - Adafruit SH110X
+ *
+ * ── Quick start ─────────────────────────────────────────────────────────────
+ *  1. Open config.h and set your WiFi credentials and desired symbols.
+ *  2. Flash to your ESP8266 via the Arduino IDE.
+ *  3. Done — no Docker, no proxy, no API key required.
+ *
+ * ── How it works ────────────────────────────────────────────────────────────
+ *  setup():  Connects to WiFi, then for every symbol fetches
+ *              • the midnight-UTC open price  (Binance klines, daily candle)
+ *              • the latest traded price      (Binance ticker/price)
+ *
+ *  loop():   Every poll_delay ms, re-fetches the current price for the
+ *            active symbol and redraws the screen if the price changed.
+ *            Symbols rotate every SECONDS_TO_DISPLAY_EACH_SYMBOL seconds.
+ *
+ * ── Memory highlights ───────────────────────────────────────────────────────
+ *  - Prices are stored in plain double[] arrays (no JSON document overhead).
+ *  - API responses are parsed as streams (never loaded into a String).
+ *  - ArduinoJson filters ensure only needed fields are allocated.
+ *  - BearSSL TLS buffers are capped via config.h (~28 KB vs default ~60 KB).
+ */
+
 #include <ESP8266WiFi.h>
-#include <ESP8266HTTPClient.h>
-#include <WiFiClientSecure.h>
-#define ARDUINOJSON_USE_DOUBLE 1
-#include <ArduinoJson.h>
 #include <Wire.h>
 #include <avr/pgmspace.h>
-
-#include "config.h"
-#include "icons.h"
-
-// Uncomment to enable verbose serial output
-// #define DEBUG
-#ifdef DEBUG
-  #define DEBUG_PRINT(x) Serial.println(x)
-#else
-  #define DEBUG_PRINT(x)
-#endif
-
 #include <Adafruit_GFX.h>
 #include <Adafruit_SH110X.h>
-#include <Fonts/FreeMonoBold9pt7b.h>
-Adafruit_SH1106G display = Adafruit_SH1106G(OLED_WIDTH, OLED_HEIGHT, &Wire, OLED_RESET);
 
-// ── Price storage ─────────────────────────────────────────────────────────────
-// Simple parallel arrays indexed by position in list_of_symbols[].
-// Replaces the old nested DynamicJsonDocument, eliminating heap fragmentation.
+#include "config.h"
+#include "debug.h"
+#include "api.h"
+#include "display_utils.h"
+
+// ── Globals ───────────────────────────────────────────────────────────────────
+
+Adafruit_SH1106G display(OLED_WIDTH, OLED_HEIGHT, &Wire, OLED_RESET);
+
+/// Last known price for each symbol (index mirrors list_of_symbols[]).
 double current_prices[size_of_list_of_symbols];
+
+/// Midnight-UTC open price for each symbol, fetched once at boot.
 double closing_prices[size_of_list_of_symbols];
 
-int  symbol_index;
-long start_time;
+int  symbol_index = 0;
+long start_time   = 0;
 
-// ── setup ─────────────────────────────────────────────────────────────────────
-void setup()
-{
+// ─────────────────────────────────────────────────────────────────────────────
+
+void setup() {
   Serial.begin(9600);
 
-  // OLED
+  // OLED init
   Wire.begin(OLED_SDA, OLED_SCL);
   delay(250);
   display.begin(OLED_I2C_ADDR, true);
@@ -45,7 +75,7 @@ void setup()
   display.println(F("Connecting..."));
   display.display();
 
-  // Built-in LED: HIGH = off (active low on ESP8266)
+  // Built-in LED is active-low on most ESP8266 boards (HIGH = off)
   pinMode(BUILTIN_LED, OUTPUT);
   digitalWrite(BUILTIN_LED, HIGH);
 
@@ -58,38 +88,42 @@ void setup()
   Serial.print(F("Connected! IP: "));
   Serial.println(WiFi.localIP());
   display.clearDisplay();
-  display.println(F("Connected to WiFi!"));
+  display.println(F("WiFi connected!"));
   display.display();
 
-  // Fetch initial prices for every symbol
+  // Fetch initial prices for all configured symbols
   for (int i = 0; i < size_of_list_of_symbols; i++) {
     closing_prices[i] = get_closing_price(list_of_symbols[i]);
     current_prices[i] = get_current_price(list_of_symbols[i]);
   }
 
-  print_to_screen(current_prices[0], current_prices[0], closing_prices[0], list_of_symbols[0]);
+  // Show the first symbol immediately
+  print_to_screen(display,
+                  current_prices[0], current_prices[0],
+                  closing_prices[0], list_of_symbols[0]);
 
-  symbol_index = 0;
-  start_time   = millis();
+  start_time = millis();
 }
 
-// ── loop ──────────────────────────────────────────────────────────────────────
-void loop()
-{
+// ─────────────────────────────────────────────────────────────────────────────
+
+void loop() {
   if (WiFi.status() != WL_CONNECTED) return;
 
-  long current_millis = millis();
+  long now = millis();
 
-  // Rotate symbol
-  if (current_millis > start_time + (SECONDS_TO_DISPLAY_EACH_SYMBOL * 1000L)) {
-    start_time = current_millis;
+  // Rotate to the next symbol once the display interval has elapsed
+  if (now > start_time + (SECONDS_TO_DISPLAY_EACH_SYMBOL * 1000L)) {
+    start_time   = now;
     symbol_index = (symbol_index + 1) % size_of_list_of_symbols;
   }
 
   double new_price = get_current_price(list_of_symbols[symbol_index]);
 
+  // Only redraw when the price has actually changed (avoids flicker)
   if (new_price > 0 && new_price != current_prices[symbol_index]) {
-    print_to_screen(new_price,
+    print_to_screen(display,
+                    new_price,
                     current_prices[symbol_index],
                     closing_prices[symbol_index],
                     list_of_symbols[symbol_index]);
@@ -97,178 +131,4 @@ void loop()
   }
 
   delay(poll_delay);
-}
-
-// ── get_current_price ─────────────────────────────────────────────────────────
-// Calls GET /api/v3/ticker/price?symbol={SYMBOL}USDT
-// Response: {"symbol":"BTCUSDT","price":"60950.01000000"}  (~60 bytes)
-//
-// Uses:
-//  • WiFiClientSecure with certificate check disabled (personal project)
-//  • Reduced TLS buffers to save ~30 KB of heap vs default
-//  • ArduinoJson filter  → only the "price" key is allocated in the document
-//  • Stream-based parsing → response is never copied into a String
-double get_current_price(const char* symbol) {
-  WiFiClientSecure client;
-  client.setInsecure();
-  client.setBufferSizes(TLS_READ_BUFFER, TLS_WRITE_BUFFER);
-
-  HTTPClient http;
-  String url = String(F("https://")) + BINANCE_HOST +
-               F("/api/v3/ticker/price?symbol=") + symbol + F("USDT");
-  DEBUG_PRINT(url);
-
-  http.begin(client, url);
-  digitalWrite(BUILTIN_LED, LOW);
-  int code = http.GET();
-  digitalWrite(BUILTIN_LED, HIGH);
-
-  double price = -1;
-
-  if (code == HTTP_CODE_OK) {
-    // Filter: discard every field except "price"
-    StaticJsonDocument<32> filter;
-    filter[F("price")] = true;
-
-    StaticJsonDocument<64> doc;
-    DeserializationError err = deserializeJson(doc, http.getStream(),
-                                               DeserializationOption::Filter(filter));
-    if (err) {
-      Serial.print(F("JSON error (current): "));
-      Serial.println(err.f_str());
-    } else {
-      price = doc[F("price")].as<double>();
-      DEBUG_PRINT(price);
-    }
-  } else {
-    Serial.print(F("HTTP error (current): "));
-    Serial.println(code);
-  }
-
-  http.end();
-  return price;
-}
-
-// ── get_closing_price ─────────────────────────────────────────────────────────
-// Calls GET /api/v3/klines?symbol={SYMBOL}USDT&interval=1d&limit=1
-// Response: [[openTime,"openPrice","highPrice","lowPrice","closePrice",...]]
-//
-// klines[0][1] = open price of today's daily candle = midnight UTC open price
-// This is semantically identical to CryptoCompare's OPENDAY field.
-//
-// The response is ~160 bytes; StaticJsonDocument<512> is plenty.
-// No filter needed at this size – the full document fits comfortably.
-double get_closing_price(const char* symbol) {
-  WiFiClientSecure client;
-  client.setInsecure();
-  client.setBufferSizes(TLS_READ_BUFFER, TLS_WRITE_BUFFER);
-
-  HTTPClient http;
-  String url = String(F("https://")) + BINANCE_HOST +
-               F("/api/v3/klines?symbol=") + symbol + F("USDT&interval=1d&limit=1");
-  DEBUG_PRINT(url);
-
-  http.begin(client, url);
-  digitalWrite(BUILTIN_LED, LOW);
-  int code = http.GET();
-  digitalWrite(BUILTIN_LED, HIGH);
-
-  double price = -1;
-
-  if (code == HTTP_CODE_OK) {
-    StaticJsonDocument<512> doc;
-    DeserializationError err = deserializeJson(doc, http.getStream());
-    if (err) {
-      Serial.print(F("JSON error (closing): "));
-      Serial.println(err.f_str());
-    } else {
-      // Array layout: [[openTime, open, high, low, close, volume, ...]]
-      price = doc[0][1].as<double>();
-      DEBUG_PRINT(price);
-    }
-  } else {
-    Serial.print(F("HTTP error (closing): "));
-    Serial.println(code);
-  }
-
-  http.end();
-  return price;
-}
-
-// ── print_to_screen ───────────────────────────────────────────────────────────
-void print_to_screen(double current_price, double previous_price, double closing_price, const char* symbol) {
-  display.clearDisplay();
-
-  // Price value
-  display.setTextSize(3);
-  String current_price_str = String(current_price, 4);
-  int dec_index = current_price_str.indexOf('.');
-  if (current_price >= 1000000) {         // 1M+
-    display.setCursor(0, 4);
-    display.print(current_price_str.substring(0, dec_index));
-  } else if (current_price >= 100000) {   // 100K–1M
-    display.setCursor(5, 4);
-    display.print(current_price_str.substring(0, dec_index));
-  } else if (current_price >= 1000) {     // 1K–100K
-    display.setCursor(5, 4);
-    display.print(current_price_str.substring(0, dec_index));
-    display.setTextSize(2);
-    display.setCursor(dec_index * 17 + 5, 11);
-    display.print(current_price_str.substring(dec_index, dec_index + (7 - dec_index)));
-  } else if (current_price >= 10) {       // 10–1K
-    display.setCursor(20, 4);
-    display.print(current_price_str.substring(0, dec_index));
-    display.setTextSize(2);
-    display.setCursor(dec_index * 17 + 20, 11);
-    display.print(current_price_str.substring(dec_index, dec_index + (6 - dec_index)));
-  } else {                                // < $10
-    display.setCursor(5, 4);
-    display.print(current_price_str);
-  }
-
-  // $ sign
-  if (current_price < 1000000) {
-    display.setCursor(115, 11);
-    display.setTextSize(2);
-    display.print('$');
-  }
-
-  // Symbol label inside rounded rectangle
-  display.setCursor(15, 37);
-  display.setTextSize(2);
-  display.print(symbol);  // already 3-char max per convention
-  display.drawRoundRect(10, 32, 44, 24, 8, SH110X_WHITE);
-
-  // Direction icon (vs midnight UTC open)
-  double diff = (current_price - closing_price) / closing_price * 100;
-  if      (diff >= 3.5)              display.drawBitmap(59, 37, bitmap_up_double,   ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
-  else if (diff >= 1.5)              display.drawBitmap(59, 37, bitmap_up_single,   ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
-  else if (diff >= 0)                display.drawBitmap(59, 37, bitmap_up_thin,     ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
-  else if (diff > -1.5)              display.drawBitmap(59, 37, bitmap_down_thin,   ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
-  else if (diff > -3.5)              display.drawBitmap(59, 37, bitmap_down_single, ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
-  else                               display.drawBitmap(59, 37, bitmap_down_double, ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
-
-  // Percentage (and optionally absolute) change
-  float pct = abs(((current_price - closing_price) / closing_price) * 100);
-  if (DIFF_PRINT_PERCENTAGE_AND_VALUE) {
-    display.setCursor(80, 35);
-    display.setTextSize(1);
-    display.print(pct, 2);
-    display.print('%');
-    display.setCursor(80, 45);
-    display.setTextSize(1);
-    display.print(abs(current_price - closing_price), 2);
-  } else {
-    display.setCursor(80, 37);
-    display.setTextSize(2);
-    display.print(pct, (pct < 10) ? 1 : 0);
-    if (pct >= 10) {
-      display.setTextSize(1);
-      display.print(' ');
-      display.setTextSize(2);
-    }
-    display.print('%');
-  }
-
-  display.display();
 }

--- a/bitcoin-tracker-oled/config.h
+++ b/bitcoin-tracker-oled/config.h
@@ -27,10 +27,12 @@ static const char* const password = "wifi_pass_here";
 static const char* const BINANCE_HOST = "api.binance.com";
 
 // TLS buffer sizes for BearSSL on ESP8266.
-// 512/512 keeps RAM usage low (~28 KB vs the default ~60 KB).
-// If you get connection failures, increase TLS_READ_BUFFER to 1024 or 4096.
-#define TLS_READ_BUFFER  512
-#define TLS_WRITE_BUFFER 512
+// Larger buffers (1024/1024) are more reliable than smaller ones (512/512),
+// especially on slower WiFi or with higher network latency.
+// If you run out of RAM or want aggressive optimisation, reduce to 512/512.
+// If you get connection failures ("-5" errors), try increasing to 2048/2048.
+#define TLS_READ_BUFFER  1024
+#define TLS_WRITE_BUFFER 1024
 
 // ── Symbols ───────────────────────────────────────────────────────────────────
 // Add/remove symbols as needed. Each must be a valid Binance base asset

--- a/bitcoin-tracker-oled/config.h
+++ b/bitcoin-tracker-oled/config.h
@@ -1,25 +1,50 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-const char* ssid = "your_ssid_here";
+// ── WiFi ─────────────────────────────────────────────────────────────────────
+const char* ssid     = "your_ssid_here";
 const char* password = "wifi_pass_here";
 
-String api_host = "http://192.168.1.113:3001";
-String current_price_path = "/api/ticker/current_price/{symbol}";
-String closing_price_path = "/api/ticker/closing_price/{symbol}";
+// ── Binance API ───────────────────────────────────────────────────────────────
+// Direct connection to Binance – no proxy needed.
+//
+// Endpoints used:
+//   Current price : GET /api/v3/ticker/price?symbol={SYMBOL}USDT
+//   Opening price : GET /api/v3/klines?symbol={SYMBOL}USDT&interval=1d&limit=1
+//                   → klines[0][1] = daily open = midnight UTC (same as OPENDAY)
+const char* BINANCE_HOST = "api.binance.com";
 
-String list_of_symbols[] = {"BTC", "ETH"};
+// TLS buffer sizes for BearSSL on ESP8266.
+// 512/512 keeps RAM usage low (~28 KB vs the default ~60 KB).
+// If you get connection failures, increase TLS_READ_BUFFER to 1024 or 4096.
+#define TLS_READ_BUFFER  512
+#define TLS_WRITE_BUFFER 512
+
+// ── Symbols ───────────────────────────────────────────────────────────────────
+// Add/remove symbols as needed. Each must be a valid Binance base asset
+// traded against USDT (e.g. "BTC" → BTCUSDT).
+const char* list_of_symbols[] = {"BTC", "ETH"};
+
+// Seconds each symbol is shown on screen before rotating to the next one
 #define SECONDS_TO_DISPLAY_EACH_SYMBOL 10
+
+// false → show only the percentage change (larger font)
+// true  → show percentage + absolute value change
 #define DIFF_PRINT_PERCENTAGE_AND_VALUE false
 
-#define OLED_SDA D1
-#define OLED_SCL D2
+// ── OLED ──────────────────────────────────────────────────────────────────────
+#define OLED_SDA      D1
+#define OLED_SCL      D2
 #define OLED_I2C_ADDR 0x3c
-#define OLED_WIDTH 128
-#define OLED_HEIGHT 64
-#define OLED_RESET -1
+#define OLED_WIDTH    128
+#define OLED_HEIGHT   64
+#define OLED_RESET    -1
 
-const int poll_delay = 1500;
+// ── Polling ───────────────────────────────────────────────────────────────────
+// Poll delay in milliseconds. 5000 ms gives the TLS handshake time to complete
+// without stalling the display. Reduce only if your network is fast and stable.
+const int poll_delay = 5000;
+
 const int size_of_list_of_symbols = sizeof(list_of_symbols) / sizeof(list_of_symbols[0]);
 
-#endif // CONFIG_H 
+#endif // CONFIG_H

--- a/bitcoin-tracker-oled/config.h
+++ b/bitcoin-tracker-oled/config.h
@@ -1,9 +1,21 @@
+/**
+ * @file config.h
+ * @brief User-facing configuration for the Bitcoin tracker.
+ *
+ * This is the only file you need to edit before flashing:
+ *  1. Set @c ssid and @c password to your WiFi credentials.
+ *  2. Adjust @c list_of_symbols to the Binance base assets you want to track.
+ *  3. Optionally tweak timing, OLED pins, or TLS buffer sizes.
+ */
 #ifndef CONFIG_H
 #define CONFIG_H
 
 // ── WiFi ─────────────────────────────────────────────────────────────────────
-const char* ssid     = "your_ssid_here";
-const char* password = "wifi_pass_here";
+// static gives these internal linkage so each .cpp translation unit gets its
+// own copy — prevents "multiple definition" linker errors when config.h is
+// included by more than one .cpp file (api.cpp, display_utils.cpp, etc.).
+static const char* const ssid     = "your_ssid_here";
+static const char* const password = "wifi_pass_here";
 
 // ── Binance API ───────────────────────────────────────────────────────────────
 // Direct connection to Binance – no proxy needed.
@@ -12,7 +24,7 @@ const char* password = "wifi_pass_here";
 //   Current price : GET /api/v3/ticker/price?symbol={SYMBOL}USDT
 //   Opening price : GET /api/v3/klines?symbol={SYMBOL}USDT&interval=1d&limit=1
 //                   → klines[0][1] = daily open = midnight UTC (same as OPENDAY)
-const char* BINANCE_HOST = "api.binance.com";
+static const char* const BINANCE_HOST = "api.binance.com";
 
 // TLS buffer sizes for BearSSL on ESP8266.
 // 512/512 keeps RAM usage low (~28 KB vs the default ~60 KB).
@@ -23,7 +35,7 @@ const char* BINANCE_HOST = "api.binance.com";
 // ── Symbols ───────────────────────────────────────────────────────────────────
 // Add/remove symbols as needed. Each must be a valid Binance base asset
 // traded against USDT (e.g. "BTC" → BTCUSDT).
-const char* list_of_symbols[] = {"BTC", "ETH"};
+static const char* const list_of_symbols[] = {"BTC", "ETH"};
 
 // Seconds each symbol is shown on screen before rotating to the next one
 #define SECONDS_TO_DISPLAY_EACH_SYMBOL 10

--- a/bitcoin-tracker-oled/debug.h
+++ b/bitcoin-tracker-oled/debug.h
@@ -10,7 +10,7 @@
  */
 #pragma once
 
-// #define DEBUG   ← uncomment to enable
+// #define DEBUG // uncomment to enable debug
 
 #ifdef DEBUG
   #define DEBUG_PRINT(x) Serial.println(x)

--- a/bitcoin-tracker-oled/debug.h
+++ b/bitcoin-tracker-oled/debug.h
@@ -1,0 +1,19 @@
+/**
+ * @file debug.h
+ * @brief Conditional debug-logging macro.
+ *
+ * To enable verbose Serial output, either uncomment the #define below or add
+ * -DDEBUG to your build flags before flashing.
+ *
+ * When DEBUG is not defined the macro expands to nothing, so there is zero
+ * runtime and flash overhead in release builds.
+ */
+#pragma once
+
+// #define DEBUG   ← uncomment to enable
+
+#ifdef DEBUG
+  #define DEBUG_PRINT(x) Serial.println(x)
+#else
+  #define DEBUG_PRINT(x)
+#endif

--- a/bitcoin-tracker-oled/display_utils.cpp
+++ b/bitcoin-tracker-oled/display_utils.cpp
@@ -1,0 +1,146 @@
+/**
+ * @file display_utils.cpp
+ * @brief OLED rendering implementation for the Bitcoin tracker.
+ */
+
+#include "display_utils.h"
+#include <avr/pgmspace.h>
+
+#include "config.h"
+#include "icons.h"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @brief Select and draw the direction bitmap based on a % change value.
+ *
+ * Thresholds (absolute %, with sign):
+ *   ≥ +3.5 → double-up   /  ≤ −3.5 → double-down
+ *   ≥ +1.5 → single-up   /  ≤ −1.5 → single-down
+ *   ≥  0   → thin-up     /  < 0    → thin-down
+ */
+static void draw_direction_icon(Adafruit_SH1106G& display, double pct_diff) {
+  const unsigned char* bmp;
+
+  if      (pct_diff >= 3.5)  bmp = bitmap_up_double;
+  else if (pct_diff >= 1.5)  bmp = bitmap_up_single;
+  else if (pct_diff >= 0)    bmp = bitmap_up_thin;
+  else if (pct_diff > -1.5)  bmp = bitmap_down_thin;
+  else if (pct_diff > -3.5)  bmp = bitmap_down_single;
+  else                       bmp = bitmap_down_double;
+
+  display.drawBitmap(59, 37, bmp, ICON_WIDTH, ICON_HEIGHT, SH110X_WHITE);
+}
+
+/**
+ * @brief Render the price number, choosing size and decimal precision by range.
+ *
+ * At text-size 3, each character is 18 px wide and the screen is 128 px wide,
+ * so the number of integer digits that fit constrains what we can show:
+ *
+ * | Range         | Integer digits | Decimal shown? |
+ * |---------------|----------------|----------------|
+ * | ≥ 1 000 000   | 7              | no             |
+ * | ≥ 100 000     | 6              | no             |
+ * | ≥ 1 000       | 2–5            | 2 digits (size 2) |
+ * | ≥ 10          | 2–3            | 2 digits (size 2) |
+ * | < 10          | 1              | 4 digits (size 3) |
+ */
+static void draw_price(Adafruit_SH1106G& display, double price) {
+  display.setTextSize(3);
+  String s         = String(price, 4);
+  int    dec_index = s.indexOf('.');
+
+  if (price >= 1000000) {
+    display.setCursor(0, 4);
+    display.print(s.substring(0, dec_index));
+  } else if (price >= 100000) {
+    display.setCursor(5, 4);
+    display.print(s.substring(0, dec_index));
+  } else if (price >= 1000) {
+    display.setCursor(5, 4);
+    display.print(s.substring(0, dec_index));
+    display.setTextSize(2);
+    display.setCursor(dec_index * 17 + 5, 11);
+    display.print(s.substring(dec_index, dec_index + (7 - dec_index)));
+  } else if (price >= 10) {
+    display.setCursor(20, 4);
+    display.print(s.substring(0, dec_index));
+    display.setTextSize(2);
+    display.setCursor(dec_index * 17 + 20, 11);
+    display.print(s.substring(dec_index, dec_index + (6 - dec_index)));
+  } else {
+    display.setCursor(5, 4);
+    display.print(s);
+  }
+
+  // Dollar sign — omitted only when the price overflows at ≥ $1 M
+  if (price < 1000000) {
+    display.setCursor(115, 11);
+    display.setTextSize(2);
+    display.print('$');
+  }
+}
+
+/**
+ * @brief Render the percentage change, and optionally the absolute change.
+ *
+ * Controlled by DIFF_PRINT_PERCENTAGE_AND_VALUE in config.h:
+ *   false → percentage only, text-size 2 (larger, easier to read at a glance)
+ *   true  → percentage + absolute $ change, text-size 1 (compact)
+ */
+static void draw_change(Adafruit_SH1106G& display,
+                        double current_price, double closing_price) {
+  float pct = fabsf((float)(current_price - closing_price)
+                    / (float)closing_price * 100.0f);
+
+  if (DIFF_PRINT_PERCENTAGE_AND_VALUE) {
+    display.setCursor(80, 35);
+    display.setTextSize(1);
+    display.print(pct, 2);
+    display.print('%');
+
+    display.setCursor(80, 45);
+    display.setTextSize(1);
+    display.print((float)fabs(current_price - closing_price), 2);
+  } else {
+    display.setCursor(80, 37);
+    display.setTextSize(2);
+    display.print(pct, (pct < 10.0f) ? 1 : 0);
+    if (pct >= 10.0f) {
+      // Nudge the '%' sign closer when there is no decimal digit
+      display.setTextSize(1);
+      display.print(' ');
+      display.setTextSize(2);
+    }
+    display.print('%');
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+void print_to_screen(Adafruit_SH1106G& display,
+                     double            current_price,
+                     double            /*previous_price*/,   // reserved for future use
+                     double            closing_price,
+                     const char*       symbol) {
+  display.clearDisplay();
+
+  draw_price(display, current_price);
+
+  // Symbol label inside a rounded rectangle
+  display.setCursor(15, 37);
+  display.setTextSize(2);
+  display.print(symbol);
+  display.drawRoundRect(10, 32, 44, 24, 8, SH110X_WHITE);
+
+  double pct_diff = (current_price - closing_price) / closing_price * 100.0;
+  draw_direction_icon(display, pct_diff);
+  draw_change(display, current_price, closing_price);
+
+  display.display();
+}

--- a/bitcoin-tracker-oled/display_utils.h
+++ b/bitcoin-tracker-oled/display_utils.h
@@ -1,0 +1,57 @@
+/**
+ * @file display_utils.h
+ * @brief OLED rendering helper for the Bitcoin tracker.
+ *
+ * The single public function @ref print_to_screen takes the display instance
+ * by reference so that this module has no global state and no dependency on
+ * the sketch's global @c display object.
+ */
+#pragma once
+
+#include <Adafruit_GFX.h>
+#include <Adafruit_SH110X.h>
+
+/**
+ * @brief Render the full price screen on the SH1106G OLED.
+ *
+ * Screen layout (128 × 64 px):
+ * @verbatim
+ * ┌──────────────────────────────────┐
+ * │  60,950              (price)    $│  ← text size 3
+ * │  .01                             │  ← text size 2 (decimals, if ≥ $1 K)
+ * │ ┌─────┐  ↑↑   3.5%              │
+ * │ │ BTC │  icon  pct               │  ← text size 2
+ * │ └─────┘                          │
+ * └──────────────────────────────────┘
+ * @endverbatim
+ *
+ * The direction bitmap is chosen from icons.h based on the % change vs the
+ * midnight-UTC open price (@p closing_price):
+ *
+ * | Range            | Icon              |
+ * |------------------|-------------------|
+ * | diff ≥ +3.5 %    | bitmap_up_double  |
+ * | +1.5 % ≤ diff    | bitmap_up_single  |
+ * |  0 %  ≤ diff     | bitmap_up_thin    |
+ * |        diff > −1.5 % | bitmap_down_thin  |
+ * |        diff > −3.5 % | bitmap_down_single|
+ * |        diff ≤ −3.5 % | bitmap_down_double|
+ *
+ * When @c DIFF_PRINT_PERCENTAGE_AND_VALUE is @c true (config.h), both the
+ * percentage and the absolute dollar change are shown in a smaller font.
+ * When @c false, only the percentage is rendered in a larger font.
+ *
+ * @param display        Reference to the SH1106G display instance.
+ * @param current_price  Most recently fetched price.
+ * @param previous_price Price from the previous poll cycle.
+ *                       Reserved for future use (e.g. flash animation on
+ *                       direction change); not rendered at the moment.
+ * @param closing_price  Midnight-UTC open price used as the daily reference.
+ * @param symbol         Asset label shown in the rounded-rectangle box.
+ *                       Should be ≤ 3 characters to fit the layout (e.g. "BTC").
+ */
+void print_to_screen(Adafruit_SH1106G& display,
+                     double            current_price,
+                     double            previous_price,
+                     double            closing_price,
+                     const char*       symbol);


### PR DESCRIPTION
## Summary

This PR removes the dependency on the Node.js/Docker proxy server and fully rewrites
the OLED sketch to connect directly to the Binance REST API. It also resolves the
root cause of the original heap exhaustion issue on the ESP8266.

## Motivation

The original architecture routed all API traffic through a local proxy
(`bitcoin-tracker-proxy`) that called CryptoCompare's `pricemultifull` endpoint.
The ESP8266 then received and parsed the full ~15 KB JSON response as a `String`,
which routinely crashed the device due to heap exhaustion (80 KB total RAM).

## What changed

### `bitcoin-tracker-oled/`

- **Direct Binance API** — removed all proxy configuration; the sketch now connects
  to `api.binance.com` over HTTPS using `WiFiClientSecure` (BearSSL).
- **Stream-based JSON parsing** — replaced `http.getString()` + `DynamicJsonDocument`
  with `deserializeJson(doc, http.getStream())` and `StaticJsonDocument` with filters.
  The full response payload is never materialised in RAM.
- **Reference price** — switched from CryptoCompare's `OPENDAY` to Binance's
  `/api/v3/klines?interval=1d&limit=1` (`klines[0][1]`), which is the midnight UTC
  daily open — semantically equivalent.
- **Modular structure** — split monolithic `.ino` into:
  - `api.h` / `api.cpp` — Binance HTTPS functions with Doxygen docs
  - `display_utils.h` / `display_utils.cpp` — OLED rendering logic
  - `debug.h` — zero-cost `DEBUG_PRINT` macro
  - `config.h` — all user-facing settings in one place; variables declared `static`
    to fix ODR linker errors when included by multiple translation units
- **TLS tuning** — BearSSL buffers set to 1024 bytes (vs 16384 default), reducing
  TLS heap cost from ~60 KB to ~28 KB. `Connection: close` header added and a 100 ms
  post-request delay added for graceful TLS teardown.
- **`README.md`** — fully rewritten: hardware wiring, configuration table, API
  endpoints, memory optimisation rationale, and a detailed troubleshooting guide for
  the most common failure mode (HTTP error `-5`).

### `bitcoin-tracker-lcd/`

- Marked as **deprecated** — added `README.md` explaining the proxy dependency,
  pointing to [`bitcoin-tracker-proxy`](https://github.com/alejandrosnz/bitcoin-tracker-proxy),
  and directing users to the OLED variant.
- Source code left intact for historical reference; no functional changes.

## Technical notes

- `const char*` variables in a shared header included by multiple `.cpp` files cause
  ODR (One Definition Rule) violations in the Arduino build system. The fix is
  `static const char* const`, which gives each translation unit its own copy.
- `ESP8266HTTPClient` does not have `setConnectTimeout()`. The timeout must be set
  on the `WiFiClientSecure` client object via `client.setTimeout()`.
- LSP errors in `.cpp` files (`'Arduino.h' not found`, etc.) are false positives —
  the Arduino build system injects platform includes automatically and these do not
  affect compilation.
